### PR TITLE
Quiet flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ build:
 run-sync: build
 	@cd ./bin && ./minima sync -c minima.yaml
 
+run-sync-quiet: build
+	@cd ./bin && ./minima sync --quiet -c minima.yaml
+
 test:
 	@$$GO_EXECUTABLE_PATH test -v -race ./...
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,20 +15,22 @@ var (
 )
 
 // RootCmd represents the base command when called without any subcommands
-var RootCmd = &cobra.Command{
-	Use:   "minima",
-	Short: "A Simple Linux Repository Manager",
-	Long:  "minima is an application to mirror and manage Linux package repos.",
-	Run: func(cmd *cobra.Command, args []string) {
-		versionFlag, _ := cmd.Flags().GetBool("version")
-		if versionFlag {
-			fmt.Printf("minima %s\n", version)
-			os.Exit(0)
-		}
+var (
+	RootCmd = &cobra.Command{
+		Use:   "minima",
+		Short: "A Simple Linux Repository Manager",
+		Long:  "minima is an application to mirror and manage Linux package repos.",
+		Run: func(cmd *cobra.Command, args []string) {
+			versionFlag, _ := cmd.Flags().GetBool("version")
+			if versionFlag {
+				fmt.Printf("minima %s\n", version)
+				os.Exit(0)
+			}
 
-		cmd.Help()
-	},
-}
+			cmd.Help()
+		},
+	}
+)
 
 // Execute adds all child commands to the root command sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
@@ -43,6 +45,7 @@ func Execute(versionTag string) {
 func init() {
 	// all sub-commands will have access to this flag
 	RootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "minima.yaml", "config file")
+	RootCmd.PersistentFlags().BoolP("quiet", "q", false, "greatly reduces the number of logs")
 	// local flags
 	RootCmd.Flags().BoolP("version", "v", false, "Print minima version")
 }

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+
 	"github.com/uyuni-project/minima/get"
 	"github.com/uyuni-project/minima/updates"
 	yaml "gopkg.in/yaml.v2"
@@ -53,9 +54,10 @@ var (
   `,
 		Run: func(cmd *cobra.Command, args []string) {
 			initConfig()
+			quiet, _ := cmd.Flags().GetBool("quiet")
 
 			var errorflag bool = false
-			syncers, err := syncersFromConfig(cfgString)
+			syncers, err := syncersFromConfig(cfgString, quiet)
 			if err != nil {
 				log.Fatal(err)
 				errorflag = true
@@ -88,7 +90,7 @@ type Config struct {
 	HTTP    []get.HTTPRepoConfig
 }
 
-func syncersFromConfig(configString string) ([]*get.Syncer, error) {
+func syncersFromConfig(configString string, quiet bool) ([]*get.Syncer, error) {
 	config, err := parseConfig(configString)
 	if err != nil {
 		return nil, err
@@ -109,7 +111,7 @@ func syncersFromConfig(configString string) ([]*get.Syncer, error) {
 			}
 		}
 
-		httpRepoConfigs, err := get.SCCToHTTPConfigs(sccUrl, config.SCC.Username, config.SCC.Password, config.SCC.Repositories)
+		httpRepoConfigs, err := get.SCCToHTTPConfigs(sccUrl, config.SCC.Username, config.SCC.Password, config.SCC.Repositories, quiet)
 		if err != nil {
 			return nil, err
 		}
@@ -138,7 +140,7 @@ func syncersFromConfig(configString string) ([]*get.Syncer, error) {
 				return nil, err
 			}
 		}
-		syncers = append(syncers, get.NewSyncer(*repoURL, archs, storage))
+		syncers = append(syncers, get.NewSyncer(*repoURL, archs, storage, quiet))
 	}
 
 	return syncers, nil

--- a/cmd/updates.go
+++ b/cmd/updates.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+
 	"github.com/uyuni-project/minima/get"
 	"github.com/uyuni-project/minima/updates"
 	yaml "gopkg.in/yaml.v2"
@@ -60,7 +61,9 @@ This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			initConfig()
-			muFindAndSync()
+			quiet, _ := cmd.Flags().GetBool("quiet")
+
+			muFindAndSync(quiet)
 		},
 	}
 	spitYamls  bool
@@ -78,7 +81,7 @@ func init() {
 	updateCmd.Flags().BoolVarP(&cleanup, "cleanup", "k", false, "flag that triggers cleaning up the storage (from old MU channels)")
 }
 
-func muFindAndSync() {
+func muFindAndSync(quiet bool) {
 	config := Config{}
 	updateList := []Updates{}
 
@@ -147,7 +150,7 @@ func muFindAndSync() {
 			os.Exit(3)
 		}
 
-		syncers, err := syncersFromConfig(string(byteChunk))
+		syncers, err := syncersFromConfig(string(byteChunk), quiet)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/get/scc.go
+++ b/get/scc.go
@@ -41,7 +41,7 @@ type Repo struct {
 type sccMap map[string][]string
 
 // SCCToHTTPConfigs returns HTTPS repos configurations (URL and archs) for repos in SCC
-func SCCToHTTPConfigs(baseURL string, username string, password string, sccConfigs []SCCReposConfig) ([]HTTPRepoConfig, error) {
+func SCCToHTTPConfigs(baseURL string, username string, password string, sccConfigs []SCCReposConfig, quiet bool) ([]HTTPRepoConfig, error) {
 	token := base64.URLEncoding.EncodeToString([]byte(username + ":" + password))
 	httpConfigs := []HTTPRepoConfig{}
 
@@ -58,7 +58,7 @@ func SCCToHTTPConfigs(baseURL string, username string, password string, sccConfi
 	var err error
 	next := baseURL + "/connect/organizations/repositories"
 
-	fmt.Println("Repos available in SCC follow:")
+	fmt.Println("Checking available SCC repositories ...")
 	for {
 		page, next, err = downloadPaged(next, token)
 		if err != nil {
@@ -72,7 +72,10 @@ func SCCToHTTPConfigs(baseURL string, username string, password string, sccConfi
 		}
 
 		for _, repo := range repos {
-			fmt.Printf("  %s: %s\n", repo.Name, repo.Description)
+			if !quiet {
+				fmt.Printf("  %s: %s\n", repo.Name, repo.Description)
+			}
+
 			config, ok := getHTTPConfig(repo.Name, repo.Description, repo.URL, sccEntries)
 			if ok {
 				httpConfigs = append(httpConfigs, config)

--- a/get/scc_test.go
+++ b/get/scc_test.go
@@ -95,7 +95,7 @@ func TestSCCToHTTPConfigs(t *testing.T) {
 					Names: tt.names,
 					Archs: tt.archs,
 				},
-			})
+			}, false)
 			assert.EqualValues(t, tt.wantErr, (err != nil))
 			assert.Equal(t, len(tt.want), len(httpConfigs))
 

--- a/get/syncer.go
+++ b/get/syncer.go
@@ -111,6 +111,7 @@ type Syncer struct {
 	URL     url.URL
 	archs   map[string]bool
 	storage Storage
+	quiet   bool
 }
 
 // Decision encodes what to do with a file
@@ -126,8 +127,8 @@ const (
 )
 
 // NewSyncer creates a new Syncer
-func NewSyncer(url url.URL, archs map[string]bool, storage Storage) *Syncer {
-	return &Syncer{url, archs, storage}
+func NewSyncer(url url.URL, archs map[string]bool, storage Storage, quiet bool) *Syncer {
+	return &Syncer{url, archs, storage, quiet}
 }
 
 // StoreRepo stores an HTTP repo in a Storage, automatically retrying in case of recoverable errors
@@ -211,7 +212,9 @@ func (r *Syncer) storeRepo(checksumMap map[string]XMLChecksum) (err error) {
 
 // downloadStoreApply downloads a repo-relative path into a file, while applying a ReaderConsumer
 func (r *Syncer) downloadStoreApply(relativePath string, checksum string, description string, hash crypto.Hash, f util.ReaderConsumer) error {
-	log.Printf("Downloading %v...", description)
+	if !r.quiet {
+		log.Printf("Downloading %v...", description)
+	}
 
 	repoURL := r.URL
 	repoURL.Path = path.Join(repoURL.Path, relativePath)
@@ -250,20 +253,29 @@ func (r *Syncer) processMetadata(checksumMap map[string]XMLChecksum) (packagesTo
 
 		data := repomd.Data
 		for i := 0; i < len(data); i++ {
-			log.Println(data[i].Location.Href)
+			if !r.quiet {
+				log.Println(data[i].Location.Href)
+			}
+
 			metadataLocation := data[i].Location.Href
 			metadataChecksum := data[i].Checksum
 
 			decision := r.decide(metadataLocation, metadataChecksum, checksumMap)
 			switch decision {
 			case Download:
-				log.Println("...downloading")
+				if !r.quiet {
+					log.Println("...downloading")
+				}
+
 				err = r.downloadStoreApply(metadataLocation, metadataChecksum.Checksum, path.Base(metadataLocation), hashMap[metadataChecksum.Type], util.Nop)
 				if err != nil {
 					return
 				}
 			case Recycle:
-				log.Println("...recycling")
+				if !r.quiet {
+					log.Println("...recycling")
+				}
+
 				r.storage.Recycle(metadataLocation)
 			}
 

--- a/get/syncer_test.go
+++ b/get/syncer_test.go
@@ -26,7 +26,7 @@ func TestStoreRepo(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	syncer := NewSyncer(*url, archs, storage)
+	syncer := NewSyncer(*url, archs, storage, false)
 
 	// first sync
 	err = syncer.StoreRepo()
@@ -83,7 +83,7 @@ func TestStoreRepoZstd(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	syncer := NewSyncer(*url, archs, storage)
+	syncer := NewSyncer(*url, archs, storage, false)
 
 	// first sync
 	err = syncer.StoreRepo()
@@ -140,7 +140,7 @@ func TestStoreDebRepo(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	syncer := NewSyncer(*url, archs, storage)
+	syncer := NewSyncer(*url, archs, storage, false)
 
 	// first sync
 	err = syncer.StoreRepo()


### PR DESCRIPTION
Introduces a --quiet flag that suppresses the following logs:

- The initial listing of available SCC products/repositories
- The log that is shown for each individual metadata file being downloaded
- The log that is shown for each individual package being downloaded

In the long run, this should probably be dropped in favor of using a logger with configurable logging levels