### PR TITLE
Handle repositories with nested repodata directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,8 @@ minima.yaml
 # Test coverage 
 
 cover.profile
+
+# IDEs
+
+.vscode
+.idea

--- a/get/filestorage.go
+++ b/get/filestorage.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"path"
+	"path/filepath"
 
 	"github.com/uyuni-project/minima/util"
 )
@@ -80,19 +81,76 @@ func (s *FileStorage) Recycle(filename string) (err error) {
 	return
 }
 
-// Commit moves any temporary file accumulated so far to the permanent location
-func (s *FileStorage) Commit() (err error) {
-	err = os.RemoveAll(s.directory + "-old")
+// Commit will take care of moving downloaded metadata and packages in the target
+// path, plus cleanup old or temporary files
+func (s *FileStorage) Commit() error {
+	oldDir := s.directory + "-old"
+	tmpDir := s.directory + "-in-progress"
+
+	// If in-progress contains actual packages, it is a candidate for being swapped with the target repo.
+	// Otherwise, it's a situation where we only have metadata in x-in-progress.
+	if hasPackages(tmpDir) {
+		os.RemoveAll(oldDir)
+
+		if err := os.Rename(s.directory, oldDir); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		if err := os.Rename(tmpDir, s.directory); err != nil {
+			return err
+		}
+
+		return os.RemoveAll(oldDir)
+	}
+
+	// Move all new files (likely just repodata) from -in-progress to the target
+	if err := mergeDirs(tmpDir, s.directory); err != nil {
+		return err
+	}
+	return os.RemoveAll(tmpDir)
+}
+
+func hasPackages(dir string) bool {
+	found := false
+	// We check for common package extensions used in Linux distros
+	filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if !info.IsDir() {
+			ext := filepath.Ext(path)
+			if _, check := packageExtensions[ext]; check {
+				found = true
+				return filepath.SkipAll // Stop walking as soon as one is found
+			}
+		}
+		return nil
+	})
+	return found
+}
+
+// mergeDirs moves the contents of the repository at source path into the repository at target path
+func mergeDirs(source, target string) error {
+	// ensure target directory exists
+	if err := os.MkdirAll(target, 0755); err != nil {
+		return err
+	}
+
+	dirs, err := os.ReadDir(source)
 	if err != nil {
-		return
+		return err
 	}
-	err = os.Rename(s.directory, s.directory+"-old")
-	if err != nil && !os.IsNotExist(err) {
-		return
+
+	for _, dir := range dirs {
+		from := filepath.Join(source, dir.Name())
+		to := filepath.Join(target, dir.Name())
+		// cleanup previous entries in the target to prevent errors
+		_ = os.RemoveAll(to)
+
+		err = os.Rename(from, to)
+		if err != nil {
+			return err
+		}
 	}
-	err = os.Rename(s.directory+"-in-progress", s.directory)
-	if err != nil {
-		return
-	}
-	return os.RemoveAll(s.directory + "-old")
+
+	return nil
 }

--- a/get/syncer.go
+++ b/get/syncer.go
@@ -80,6 +80,11 @@ type RepoType struct {
 }
 
 var (
+	packageExtensions = map[string]struct{}{
+		".rpm":  {},
+		".deb":  {},
+		".udeb": {},
+	}
 	repoTypes = map[string]RepoType{
 		"rpm": {
 			MetadataPath: "repodata/repomd.xml",
@@ -252,13 +257,13 @@ func (r *Syncer) processMetadata(checksumMap map[string]XMLChecksum) (packagesTo
 		}
 
 		data := repomd.Data
-		for i := 0; i < len(data); i++ {
+		for _, entry := range data {
 			if !r.quiet {
-				log.Println(data[i].Location.Href)
+				log.Println(entry.Location.Href)
 			}
 
-			metadataLocation := data[i].Location.Href
-			metadataChecksum := data[i].Checksum
+			metadataLocation := entry.Location.Href
+			metadataChecksum := entry.Checksum
 
 			decision := r.decide(metadataLocation, metadataChecksum, checksumMap)
 			switch decision {
@@ -279,7 +284,7 @@ func (r *Syncer) processMetadata(checksumMap map[string]XMLChecksum) (packagesTo
 				r.storage.Recycle(metadataLocation)
 			}
 
-			if data[i].Type == repoType.PackagesType {
+			if entry.Type == repoType.PackagesType {
 				packagesToDownload, packagesToRecycle, err = r.processPrimary(metadataLocation, checksumMap, repoType)
 			}
 		}
@@ -455,7 +460,9 @@ func (r *Syncer) processPrimary(path string, checksumMap map[string]XMLChecksum,
 		legacyPackage := (pack.Arch == "i586" || pack.Arch == "i686")
 
 		if SkipLegacy && legacyPackage {
-			fmt.Println("Skipping legacy package:", pack.Location.Href)
+			if !r.quiet {
+				fmt.Println("Skipping legacy package:", pack.Location.Href)
+			}
 			continue
 		}
 


### PR DESCRIPTION
Related to https://github.com/SUSE/spacewalk/issues/30289

We need to handle repositories such as https://download.opensuse.org/distribution/leap/16.0/repo/oss/ where each architecture sub-directory has its own repodata directory, listing pkgs for the given arch.
Currently this does not work as intended because minima will:
- create a tmp work directory e.g. aarch64-in-progress
- download the metadata in /repodata in there
 - see this metadata points to packages in aarch64
 - download them there or verify they've been downloaded previosly
 - once finished, proceed to move "aarch64-in-progress" to "aarch64"
 - therefore keep only the /repodata subdirectory, throwing away dowloaded packages
 
We need to handle this repository setup either during download or when moving directories around to finalize changes.
The 1st choice may require additional config variables and to refactor download logic.
The 2nd is implemented is this PR and uses a simple heuristic: if in the x-in-progress repository does NOT contain any pkg it assumes we're in the above situation and proceeds to "merge" (instead of swapping with a rename) x-in-progress with x - effectively just overriding the old "repodata" files.