### PR TITLE
Fix missing deb-like metadate files when syncing

### DIFF
--- a/get/syncer.go
+++ b/get/syncer.go
@@ -71,12 +71,13 @@ const repomdPath = "repodata/repomd.xml"
 const releasePath = "Release"
 
 type RepoType struct {
-	MetadataPath         string
-	PackagesType         string
-	DecodeMetadata       func(io.Reader) (XMLRepomd, error)
-	DecodePackages       func(io.Reader, string) (XMLMetaData, error)
-	MetadataSignatureExt string
-	Noarch               string
+	MetadataPath              string
+	PackagesType              string
+	DecodeMetadata            func(io.Reader) (XMLRepomd, error)
+	DecodePackages            func(io.Reader, string) (XMLMetaData, error)
+	MetadataSignatureExt      string
+	Noarch                    string
+	AdditionalMetadataPaths   []string
 }
 
 var (
@@ -99,12 +100,13 @@ var (
 			Noarch:               "noarch",
 		},
 		"deb": {
-			MetadataPath:         "Release",
-			PackagesType:         "Packages",
-			DecodeMetadata:       decodeRelease,
-			DecodePackages:       decodePackages,
-			MetadataSignatureExt: ".gpg",
-			Noarch:               "all",
+			MetadataPath:            "Release",
+			PackagesType:            "Packages",
+			DecodeMetadata:          decodeRelease,
+			DecodePackages:          decodePackages,
+			MetadataSignatureExt:    ".gpg",
+			Noarch:                  "all",
+			AdditionalMetadataPaths: []string{"InRelease", "Release.gpg", "Release.key"},
 		},
 	}
 	SkipLegacy bool
@@ -307,12 +309,11 @@ func (r *Syncer) processMetadata(checksumMap map[string]XMLChecksum) (packagesTo
 			return
 		}
 
-		// DEB succeeded - download additional signature files
+		// DEB succeeded - download additional metadata files
 		// Note: Release.gpg and Release.key may have been downloaded by checkRepomdSignature()
 		// for verification. Check if they already exist before re-downloading.
-		extraFiles := []string{"InRelease", "Release.gpg", "Release.key"}
 		isManagerTools := strings.Contains(r.URL.String(), "MultiLinuxManagerTools")
-		for _, file := range extraFiles {
+		for _, file := range repoTypes["deb"].AdditionalMetadataPaths {
 			// Avoid re-downloading signature/key if they were already fetched during signature verification.
 			if file == "Release.gpg" || file == "Release.key" {
 				if reader, rerr := r.storage.NewReader(file, Temporary); rerr == nil {

--- a/get/syncer.go
+++ b/get/syncer.go
@@ -303,9 +303,51 @@ func (r *Syncer) processMetadata(checksumMap map[string]XMLChecksum) (packagesTo
 			err = doProcessMetadata(reader, repoTypes["deb"])
 			return
 		})
-		return
-	}
+		if err != nil {
+			return
+		}
 
+		// DEB succeeded - download additional signature files
+		// Note: Release.gpg and Release.key may have been downloaded by checkRepomdSignature()
+		// for verification. Check if they already exist before re-downloading.
+		extraFiles := []string{"InRelease", "Release.gpg", "Release.key"}
+		isManagerTools := strings.Contains(r.URL.String(), "MultiLinuxManagerTools")
+		for _, file := range extraFiles {
+			// Avoid re-downloading signature/key if they were already fetched during signature verification.
+			if file == "Release.gpg" || file == "Release.key" {
+				if reader, rerr := r.storage.NewReader(file, Temporary); rerr == nil {
+					_ = reader.Close()
+					continue
+				} else if rerr != ErrFileNotFound {
+					err = rerr
+					return
+				}
+			}
+
+			extraErr := r.downloadStoreApply(file, "", file, 0, util.Nop)
+			if extraErr == nil {
+				continue
+			}
+
+			// Only strictly enforce Release.gpg for MultiLinuxManagerTools repositories.
+			if isManagerTools && file == "Release.gpg" {
+				// Don't ignore any errors for required file; propagate so StoreRepo can retry.
+				err = extraErr
+				return
+			}
+
+			// For optional files, ignore 403/404 (file doesn't exist)
+			ignoredErr := ignoreStatusCode(extraErr, 403, 404)
+			if ignoredErr == nil {
+				continue
+			}
+
+			// Non-403/404 error on optional file: propagate so StoreRepo can retry instead of committing corrupt state
+			log.Printf("Failed to download optional file %s, retrying sync: %v\n", file, ignoredErr)
+			err = ignoredErr
+			return
+		}
+	}
 	return
 }
 


### PR DESCRIPTION
Fixes https://github.com/uyuni-project/minima/issues/93. The fix was mostly done by Claude, so please pay attention to the changes.

I did some tests on our minima mirror:

I deleted `InRelease Release.gpg Release.key`

and triggered a new sync of

```yaml
  repositories:
    - names:
      - Debian-13-SUSE-Manager-Tools
      - ManagerTools-Debian13-Updates
      - Debian-13-SUSE-Manager-Tools-Beta
      - ManagerTools-Debian13-Beta-Updates
      archs: [amd64, arm64]
```

All files were downloaded properly:

### Non-Beta Tools
```bash

minima-mirror-ci-bv:/srv/mirror/SUSE/Updates/MultiLinuxManagerTools/Debian-13/x86_64/update # ll
total 24
-rw-r--r-- 1 root root 1283 Jun 19 11:51 InRelease
-rw-r--r-- 1 root root 3987 Jun 18 14:55 Packages
-rw-r--r-- 1 root root 1486 Jun 18 14:55 Packages.gz
-rw-r--r-- 1 root root  712 Jun 19 11:51 Release
-rw-r--r-- 1 root root  522 Jun 19 11:51 Release.gpg
-rw-r--r-- 1 root root  969 Jun 19 11:51 Release.key
drwxr-xr-x 2 root root  243 Jun 19 11:51 all
drwxr-xr-x 2 root root  116 Jun 19 11:51 amd64

minima-mirror-ci-bv:/srv/mirror/SUSE/Updates/MultiLinuxManagerTools/Debian-13/aarch64/update # ll
total 24
-rw-r--r-- 1 root root 1281 Jun 19 11:51 InRelease
-rw-r--r-- 1 root root 3986 Jun 11 20:21 Packages
-rw-r--r-- 1 root root 1488 Jun 11 20:21 Packages.gz
-rw-r--r-- 1 root root  710 Jun 19 11:51 Release
-rw-r--r-- 1 root root  522 Jun 19 11:51 Release.gpg
-rw-r--r-- 1 root root  969 Jun 19 11:51 Release.key
drwxr-xr-x 2 root root  243 Jun 19 11:51 all
drwxr-xr-x 2 root root  116 Jun 19 11:51 arm64
```

### Beta Tools
```bash
minima-mirror-ci-bv:/srv/mirror/SUSE/Updates/MultiLinuxManagerTools-Beta/Debian-13/x86_64/update # ll
total 24
-rw-r--r-- 1 root root 1298 Jun 19 11:51 InRelease
-rw-r--r-- 1 root root 3986 May 18 21:47 Packages
-rw-r--r-- 1 root root 1489 May 18 21:47 Packages.gz
-rw-r--r-- 1 root root  727 Jun 19 11:51 Release
-rw-r--r-- 1 root root  522 Jun 19 11:51 Release.gpg
-rw-r--r-- 1 root root  969 Jun 19 11:51 Release.key
drwxr-xr-x 2 root root  219 Jun 19 11:51 all
drwxr-xr-x 2 root root  103 Jun 19 11:51 amd64

minima-mirror-ci-bv:/srv/mirror/SUSE/Updates/MultiLinuxManagerTools-Beta/Debian-13/aarch64/update # ll
total 24
-rw-r--r-- 1 root root 1296 Jun 19 11:51 InRelease
-rw-r--r-- 1 root root 3986 Jun 10 21:47 Packages
-rw-r--r-- 1 root root 1494 Jun 10 21:47 Packages.gz
-rw-r--r-- 1 root root  725 Jun 19 11:51 Release
-rw-r--r-- 1 root root  522 Jun 19 11:51 Release.gpg
-rw-r--r-- 1 root root  969 Jun 19 11:51 Release.key
drwxr-xr-x 2 root root  239 Jun 19 11:51 all
drwxr-xr-x 2 root root  115 Jun 19 11:51 arm64
```

I also tried with removing the actual packages and resync:

```bash
minima-mirror-ci-bv:/srv/mirror/SUSE/Updates/MultiLinuxManagerTools/Debian-13/x86_64/update # ll
total 24
-rw-r--r-- 1 root root 1283 Jun 19 11:58 InRelease
-rw-r--r-- 1 root root 3987 Jun 19 11:58 Packages
-rw-r--r-- 1 root root 1486 Jun 19 11:58 Packages.gz
-rw-r--r-- 1 root root  712 Jun 19 11:58 Release
-rw-r--r-- 1 root root  522 Jun 19 11:58 Release.gpg
-rw-r--r-- 1 root root  969 Jun 19 11:58 Release.key
drwxr-xr-x 2 root root  243 Jun 19 11:58 all
drwxr-xr-x 2 root root  116 Jun 19 11:58 amd64

minima-mirror-ci-bv:/srv/mirror/SUSE/Updates/MultiLinuxManagerTools/Debian-13/x86_64/update # tree
.
├── InRelease
├── Packages
├── Packages.gz
├── Release
├── Release.gpg
├── Release.key
├── all
│   ├── mgrctl-bash-completion_5.1.26-130002.2.3.4_all.deb
│   ├── mgrctl-fish-completion_5.1.26-130002.2.3.4_all.deb
│   ├── mgrctl-zsh-completion_5.1.26-130002.2.3.4_all.deb
│   └── spacecmd_5.1.13-130002.2.3.5_all.deb
└── amd64
    ├── mgrctl_5.1.26-130002.2.3.4_amd64.deb
    └── venv-salt-minion_3006.0-130002.2.3.1_amd64.deb

2 directories, 12 files
```

## Tests

However I did not add new tests.

```bash
go test -v ./...
?       github.com/uyuni-project/minima [no test files]
=== RUN   TestParseConfig
=== RUN   TestParseConfig/Valid_HTTP_repos
=== RUN   TestParseConfig/Valid_SCC_repos
=== RUN   TestParseConfig/Invalid_storage
--- PASS: TestParseConfig (0.00s)
    --- PASS: TestParseConfig/Valid_HTTP_repos (0.00s)
    --- PASS: TestParseConfig/Valid_SCC_repos (0.00s)
    --- PASS: TestParseConfig/Invalid_storage (0.00s)
=== RUN   TestArchMage
=== RUN   TestArchMage/Arch_in_repo_URL
=== RUN   TestArchMage/Single_available_arch_for_a_repo
=== RUN   TestArchMage/Multiple_available_archs_for_a_repo
=== RUN   TestArchMage/No_available_archs_for_a_repo
--- PASS: TestArchMage (0.00s)
    --- PASS: TestArchMage/Arch_in_repo_URL (0.00s)
    --- PASS: TestArchMage/Single_available_arch_for_a_repo (0.00s)
    --- PASS: TestArchMage/Multiple_available_archs_for_a_repo (0.00s)
    --- PASS: TestArchMage/No_available_archs_for_a_repo (0.00s)
=== RUN   TestProcWebChunk
=== RUN   TestProcWebChunk/Valid_maint_repo_-_single_valid_arch
{http://download.suse.de/ibs/SUSE:/Maintenance:/2/SUSE_SLE-15-SP4_Update/ [aarch64]}
=== RUN   TestProcWebChunk/Valid_maint_repo_-_multiple_valid_archs
{http://download.suse.de/ibs/SUSE:/Maintenance:/3/SUSE_SLE-15-SP4_Update/ [x86_64 aarch64 s390x ppc64le]}
=== RUN   TestProcWebChunk/Valid_maint_repo_-_no_valid_archs
=== RUN   TestProcWebChunk/Network_error
--- PASS: TestProcWebChunk (0.00s)
    --- PASS: TestProcWebChunk/Valid_maint_repo_-_single_valid_arch (0.00s)
    --- PASS: TestProcWebChunk/Valid_maint_repo_-_multiple_valid_archs (0.00s)
    --- PASS: TestProcWebChunk/Valid_maint_repo_-_no_valid_archs (0.00s)
    --- PASS: TestProcWebChunk/Network_error (0.00s)
=== RUN   TestGetProductsForMU
=== RUN   TestGetProductsForMU/Chunk_without_'SUSE'_is_discarded
GET http://download.suse.de/ibs/SUSE:/Maintenance:/6/
=== RUN   TestGetProductsForMU/Network_error
GET http://download.suse.de/ibs/SUSE:/Maintenance:/7/
--- PASS: TestGetProductsForMU (0.00s)
    --- PASS: TestGetProductsForMU/Chunk_without_'SUSE'_is_discarded (0.00s)
    --- PASS: TestGetProductsForMU/Network_error (0.00s)
=== RUN   TestGetRepo
=== RUN   TestGetRepo/Single_arch
GET http://download.suse.de/ibs/SUSE:/Maintenance:/8/
2 product entries for mu http://download.suse.de/ibs/SUSE:/Maintenance:/8/
{http://download.suse.de/ibs/SUSE:/Maintenance:/8/SUSE_SLE-15-SP4_Update/ [x86_64]}
{http://download.suse.de/ibs/SUSE:/Maintenance:/8/SUSE_SLE-15-SP6_Update/ [x86_64]}
=== RUN   TestGetRepo/Multiple_archs
GET http://download.suse.de/ibs/SUSE:/Maintenance:/9/
2 product entries for mu http://download.suse.de/ibs/SUSE:/Maintenance:/9/
{http://download.suse.de/ibs/SUSE:/Maintenance:/9/SUSE_SLE-15-SP4_Update/ [x86_64 aarch64 ppc64le s390x]}
{http://download.suse.de/ibs/SUSE:/Maintenance:/9/SUSE_SLE-15-SP6_Update/ [x86_64 ppc64le aarch64 s390x]}
=== RUN   TestGetRepo/No_available_archs
GET http://download.suse.de/ibs/SUSE:/Maintenance:/10/
2 product entries for mu http://download.suse.de/ibs/SUSE:/Maintenance:/10/
=== RUN   TestGetRepo/Network_error
GET http://download.suse.de/ibs/SUSE:/Maintenance:/11/
--- PASS: TestGetRepo (0.00s)
    --- PASS: TestGetRepo/Single_arch (0.00s)
    --- PASS: TestGetRepo/Multiple_archs (0.00s)
    --- PASS: TestGetRepo/No_available_archs (0.00s)
    --- PASS: TestGetRepo/Network_error (0.00s)
PASS
ok      github.com/uyuni-project/minima/cmd     (cached)
=== RUN   TestReadURL
--- PASS: TestReadURL (0.02s)
=== RUN   TestSCCToHTTPConfigs
=== RUN   TestSCCToHTTPConfigs/One_name_and_no_matching_arch
Checking available SCC repositories ...
  SLES15-SP5-Pool: x86_64 aarch64 i586
  SLES15-SP5-Updates: x86_64 aarch64 s390x ppc64le
=== RUN   TestSCCToHTTPConfigs/One_name_and_one_matching_arch
Checking available SCC repositories ...
  SLES15-SP5-Pool: x86_64 aarch64 i586
  SLES15-SP5-Updates: x86_64 aarch64 s390x ppc64le
=== RUN   TestSCCToHTTPConfigs/One_name_and_multiple_matching_archs
Checking available SCC repositories ...
  SLES15-SP5-Pool: x86_64 aarch64 i586
  SLES15-SP5-Updates: x86_64 aarch64 s390x ppc64le
=== RUN   TestSCCToHTTPConfigs/Multiple_names_and_no_matching_archs
Checking available SCC repositories ...
  SLES15-SP5-Pool: x86_64 aarch64 i586
  SLES15-SP5-Updates: x86_64 aarch64 s390x ppc64le
=== RUN   TestSCCToHTTPConfigs/Multiple_names_and_multiple_matching_archs
Checking available SCC repositories ...
  SLES15-SP5-Pool: x86_64 aarch64 i586
  SLES15-SP5-Updates: x86_64 aarch64 s390x ppc64le
=== RUN   TestSCCToHTTPConfigs/Invalid_user
Checking available SCC repositories ...
=== RUN   TestSCCToHTTPConfigs/Invalid_password
Checking available SCC repositories ...
--- PASS: TestSCCToHTTPConfigs (0.00s)
    --- PASS: TestSCCToHTTPConfigs/One_name_and_no_matching_arch (0.00s)
    --- PASS: TestSCCToHTTPConfigs/One_name_and_one_matching_arch (0.00s)
    --- PASS: TestSCCToHTTPConfigs/One_name_and_multiple_matching_archs (0.00s)
    --- PASS: TestSCCToHTTPConfigs/Multiple_names_and_no_matching_archs (0.00s)
    --- PASS: TestSCCToHTTPConfigs/Multiple_names_and_multiple_matching_archs (0.00s)
    --- PASS: TestSCCToHTTPConfigs/Invalid_user (0.00s)
    --- PASS: TestSCCToHTTPConfigs/Invalid_password (0.00s)
=== RUN   TestStoreRepo
2026/06/19 15:40:13 First-time sync started
2026/06/19 15:40:13 Downloading repomd.xml...
2026/06/19 15:40:13 Downloading repomd.xml.asc...
2026/06/19 15:40:13 Got 404, ignoring...
2026/06/19 15:40:13 repodata/06288a8a3ec708ceabe3197087e9aa93cbf4d5b81a391857c0cbec9a676fdba2-filelists.xml.gz
2026/06/19 15:40:13 ...downloading
2026/06/19 15:40:13 Downloading 06288a8a3ec708ceabe3197087e9aa93cbf4d5b81a391857c0cbec9a676fdba2-filelists.xml.gz...
2026/06/19 15:40:13 repodata/0967c2f17755f88a7e8b2185a9b2a87d72cc3f10cc3574e3fcedd997e84db42b-updateinfo.xml.gz
2026/06/19 15:40:13 ...downloading
2026/06/19 15:40:13 Downloading 0967c2f17755f88a7e8b2185a9b2a87d72cc3f10cc3574e3fcedd997e84db42b-updateinfo.xml.gz...
2026/06/19 15:40:13 repodata/f08a89e1946493d15313244a30a2962e7a43fc07205b9f7fca1ebeec3c6d2d2e-other.xml.gz
2026/06/19 15:40:13 ...downloading
2026/06/19 15:40:13 Downloading f08a89e1946493d15313244a30a2962e7a43fc07205b9f7fca1ebeec3c6d2d2e-other.xml.gz...
2026/06/19 15:40:13 repodata/dadb7d32493327d1afdead2b4f191f8bcd449bcfe48fda241a0b94555c5495f6-primary.xml.gz
2026/06/19 15:40:13 ...downloading
2026/06/19 15:40:13 Downloading dadb7d32493327d1afdead2b4f191f8bcd449bcfe48fda241a0b94555c5495f6-primary.xml.gz...
2026/06/19 15:40:13 Downloading 12 packages...
2026/06/19 15:40:13 Downloading (1/12) andromeda-dummy-2.0-1.1.noarch.rpm...
2026/06/19 15:40:13 Downloading (2/12) hoag-dummy-1.1-2.1.x86_64.rpm...
2026/06/19 15:40:13 Downloading (3/12) milkyway-dummy-2.0-1.1.x86_64.rpm...
2026/06/19 15:40:13 Downloading (4/12) orion-dummy-1.1-1.1.x86_64.rpm...
2026/06/19 15:40:13 Downloading (5/12) orion-dummy-sle12-1.1-4.1.x86_64.rpm...
2026/06/19 15:40:13 Downloading (6/12) perseus-dummy-1.1-1.1.x86_64.rpm...
2026/06/19 15:40:13 Downloading (7/12) virgo-dummy-2.0-1.1.noarch.rpm...
2026/06/19 15:40:13 Downloading (8/12) hoag-dummy-1.1-2.1.i586.rpm...
2026/06/19 15:40:13 Downloading (9/12) milkyway-dummy-2.0-1.1.i586.rpm...
2026/06/19 15:40:13 Downloading (10/12) orion-dummy-1.1-1.1.i586.rpm...
2026/06/19 15:40:13 Downloading (11/12) orion-dummy-sle12-1.1-4.1.i586.rpm...
2026/06/19 15:40:13 Downloading (12/12) perseus-dummy-1.1-1.1.i586.rpm...
2026/06/19 15:40:13 Recycling 0 packages...
2026/06/19 15:40:13 Committing changes...
2026/06/19 15:40:13 Downloading repomd.xml...
2026/06/19 15:40:13 Downloading repomd.xml.asc...
2026/06/19 15:40:13 Got 404, ignoring...
2026/06/19 15:40:13 repodata/06288a8a3ec708ceabe3197087e9aa93cbf4d5b81a391857c0cbec9a676fdba2-filelists.xml.gz
2026/06/19 15:40:13 ...recycling
2026/06/19 15:40:13 repodata/0967c2f17755f88a7e8b2185a9b2a87d72cc3f10cc3574e3fcedd997e84db42b-updateinfo.xml.gz
2026/06/19 15:40:13 ...recycling
2026/06/19 15:40:13 repodata/f08a89e1946493d15313244a30a2962e7a43fc07205b9f7fca1ebeec3c6d2d2e-other.xml.gz
2026/06/19 15:40:13 ...recycling
2026/06/19 15:40:13 repodata/dadb7d32493327d1afdead2b4f191f8bcd449bcfe48fda241a0b94555c5495f6-primary.xml.gz
2026/06/19 15:40:13 ...recycling
2026/06/19 15:40:13 Downloading 0 packages...
2026/06/19 15:40:13 Recycling 12 packages...
2026/06/19 15:40:13 Committing changes...
--- PASS: TestStoreRepo (0.02s)
=== RUN   TestStoreRepoZstd
2026/06/19 15:40:13 First-time sync started
2026/06/19 15:40:13 Downloading repomd.xml...
2026/06/19 15:40:13 Downloading repomd.xml.asc...
2026/06/19 15:40:13 Got 404, ignoring...
2026/06/19 15:40:13 repodata/d7fd4cf502d9e1ab8865bc9690c34c3cadcfda0db269f4ddc9c6f026db3f2400-primary.xml.zst
2026/06/19 15:40:13 ...downloading
2026/06/19 15:40:13 Downloading d7fd4cf502d9e1ab8865bc9690c34c3cadcfda0db269f4ddc9c6f026db3f2400-primary.xml.zst...
2026/06/19 15:40:13 repodata/106c411e443c6b97e7d547f78e32d6d2cdf8e80577999954fdb770d8a21581a0-filelists.xml.zst
2026/06/19 15:40:13 ...downloading
2026/06/19 15:40:13 Downloading 106c411e443c6b97e7d547f78e32d6d2cdf8e80577999954fdb770d8a21581a0-filelists.xml.zst...
2026/06/19 15:40:13 repodata/fa0767ea9359279bb6e8ec93a70cefb3863e4fa4bcbeebbfe755a5ce16c21b94-other.xml.zst
2026/06/19 15:40:13 ...downloading
2026/06/19 15:40:13 Downloading fa0767ea9359279bb6e8ec93a70cefb3863e4fa4bcbeebbfe755a5ce16c21b94-other.xml.zst...
2026/06/19 15:40:13 Downloading 5 packages...
2026/06/19 15:40:13 Downloading (1/5) hoag-dummy-1.1-2.1.x86_64.rpm...
2026/06/19 15:40:13 Downloading (2/5) milkyway-dummy-2.0-1.1.x86_64.rpm...
2026/06/19 15:40:13 Downloading (3/5) orion-dummy-1.1-1.1.x86_64.rpm...
2026/06/19 15:40:13 Downloading (4/5) orion-dummy-sle12-1.1-4.1.x86_64.rpm...
2026/06/19 15:40:13 Downloading (5/5) perseus-dummy-1.1-1.1.x86_64.rpm...
2026/06/19 15:40:13 Recycling 0 packages...
2026/06/19 15:40:13 Committing changes...
2026/06/19 15:40:13 Downloading repomd.xml...
2026/06/19 15:40:13 Downloading repomd.xml.asc...
2026/06/19 15:40:13 Got 404, ignoring...
2026/06/19 15:40:13 repodata/d7fd4cf502d9e1ab8865bc9690c34c3cadcfda0db269f4ddc9c6f026db3f2400-primary.xml.zst
2026/06/19 15:40:13 ...recycling
2026/06/19 15:40:13 repodata/106c411e443c6b97e7d547f78e32d6d2cdf8e80577999954fdb770d8a21581a0-filelists.xml.zst
2026/06/19 15:40:13 ...recycling
2026/06/19 15:40:13 repodata/fa0767ea9359279bb6e8ec93a70cefb3863e4fa4bcbeebbfe755a5ce16c21b94-other.xml.zst
2026/06/19 15:40:13 ...recycling
2026/06/19 15:40:13 Downloading 0 packages...
2026/06/19 15:40:13 Recycling 5 packages...
2026/06/19 15:40:13 Committing changes...
--- PASS: TestStoreRepoZstd (0.01s)
=== RUN   TestStoreDebRepo
2026/06/19 15:40:13 First-time sync started
2026/06/19 15:40:13 Downloading repomd.xml...
2026/06/19 15:40:13 Got unexpected status code from http://localhost:8080/deb_repo/repodata/repomd.xml?, 404
2026/06/19 15:40:13 Fallback to next repo type
2026/06/19 15:40:13 Downloading Release...
2026/06/19 15:40:13 Downloading Release.gpg...
2026/06/19 15:40:13 Got 404, ignoring...
2026/06/19 15:40:13 Packages
2026/06/19 15:40:13 ...downloading
2026/06/19 15:40:13 Downloading Packages...
2026/06/19 15:40:13 Packages.gz
2026/06/19 15:40:13 ...downloading
2026/06/19 15:40:13 Downloading Packages.gz...
2026/06/19 15:40:13 Downloading InRelease...
2026/06/19 15:40:13 Got 404, ignoring...
2026/06/19 15:40:13 Downloading Release.gpg...
2026/06/19 15:40:13 Got 404, ignoring...
2026/06/19 15:40:13 Downloading Release.key...
2026/06/19 15:40:13 Got 404, ignoring...
2026/06/19 15:40:13 Downloading 7 packages...
2026/06/19 15:40:13 Downloading (1/7) hoag-dummy_1.1-2.1_amd64.deb...
2026/06/19 15:40:13 Downloading (2/7) milkyway-dummy_2.0-1.1_amd64.deb...
2026/06/19 15:40:13 Downloading (3/7) orion-dummy_1.1-1.1_amd64.deb...
2026/06/19 15:40:13 Downloading (4/7) orion-dummy-sle12_1.1-4.1_amd64.deb...
2026/06/19 15:40:13 Downloading (5/7) perseus-dummy_1.1-1.1_amd64.deb...
2026/06/19 15:40:13 Downloading (6/7) andromeda-dummy_2.0-2.1_all.deb...
2026/06/19 15:40:13 Downloading (7/7) virgo-dummy_2.0-2.1_all.deb...
2026/06/19 15:40:13 Recycling 0 packages...
2026/06/19 15:40:13 Committing changes...
2026/06/19 15:40:13 Downloading repomd.xml...
2026/06/19 15:40:13 Got unexpected status code from http://localhost:8080/deb_repo/repodata/repomd.xml?, 404
2026/06/19 15:40:13 Fallback to next repo type
2026/06/19 15:40:13 Downloading Release...
2026/06/19 15:40:13 Downloading Release.gpg...
2026/06/19 15:40:13 Got 404, ignoring...
2026/06/19 15:40:13 Packages
2026/06/19 15:40:13 ...recycling
2026/06/19 15:40:13 Packages.gz
2026/06/19 15:40:13 ...recycling
2026/06/19 15:40:13 Downloading InRelease...
2026/06/19 15:40:13 Got 404, ignoring...
2026/06/19 15:40:13 Downloading Release.gpg...
2026/06/19 15:40:13 Got 404, ignoring...
2026/06/19 15:40:13 Downloading Release.key...
2026/06/19 15:40:13 Got 404, ignoring...
2026/06/19 15:40:13 Downloading 0 packages...
2026/06/19 15:40:13 Recycling 7 packages...
2026/06/19 15:40:13 Committing changes...
--- PASS: TestStoreDebRepo (0.01s)
PASS
ok      github.com/uyuni-project/minima/get     0.450s
?       github.com/uyuni-project/minima/updates [no test files]
=== RUN   TestProcessPropertiesFile
--- PASS: TestProcessPropertiesFile (0.00s)
=== RUN   TestCompose
--- PASS: TestCompose (0.00s)
PASS
ok      github.com/uyuni-project/minima/util    (cached)
```