### PR TITLE
Refactor repositories handling in syncer, plus fixes and style alignment

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -95,9 +95,6 @@ func syncersFromConfig(configString string, quiet bool) ([]*get.Syncer, error) {
 	if err != nil {
 		return nil, err
 	}
-	//---passing the flag value to a global variable in get package, to disables syncing of i586 and i686 rpms (usually inside x86_64)
-	get.SkipLegacy = skipLegacyPackages
-
 	if config.SCC.Username != "" {
 		if thisRepo != "" {
 			if archs == "" {
@@ -140,7 +137,7 @@ func syncersFromConfig(configString string, quiet bool) ([]*get.Syncer, error) {
 				return nil, err
 			}
 		}
-		syncers = append(syncers, get.NewSyncer(*repoURL, archs, storage, quiet))
+		syncers = append(syncers, get.NewSyncer(*repoURL, archs, storage, quiet, skipLegacyPackages))
 	}
 
 	return syncers, nil

--- a/cmd/updates.go
+++ b/cmd/updates.go
@@ -235,56 +235,43 @@ func ArchMage(client *http.Client, repo *get.HTTPRepoConfig) error {
 }
 
 // GetRepo retrieves HTTP repositories data for all the products targets associated to an MU
-func GetRepo(client *http.Client, mu string) (httpFormattedRepos []get.HTTPRepoConfig, err error) {
+func GetRepo(client *http.Client, mu string) ([]get.HTTPRepoConfig, error) {
 	productsChunks, err := getProductsForMU(client, mu)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving products for MU %s: %v", mu, err)
 	}
 	fmt.Printf("%d product entries for mu %s\n", len(productsChunks), mu)
 
-	reposChan := make(chan []get.HTTPRepoConfig)
-	errChan := make(chan error)
-	// empty struct for 0 allocation: we need only to signal we're done, not pass data
-	doneChan := make(chan struct{})
+	n := len(productsChunks)
+	reposChan := make(chan []get.HTTPRepoConfig, n)
+	errChan := make(chan error, n)
 
-	// we need a dedicated goroutine to start the others, wait for them to finish
-	// and signal back that we're done processing
-	go func() {
-		var wg sync.WaitGroup
-		wg.Add(len(productsChunks))
-
-		// process each chunk (possibly) in parallel
-		for _, productChunk := range productsChunks {
-			go func(product, maint string) {
-				defer wg.Done()
-
-				repo, err := ProcWebChunk(client, product, maint)
-				if err != nil {
-					errChan <- err
-				}
-				reposChan <- repo
-
-			}(productChunk, mu)
-		}
-
-		wg.Wait()
-		close(reposChan)
-		doneChan <- struct{}{}
-	}()
-
-	// keeps looping untill we're done processing all chunks or an error occurs
-	for {
-		select {
-		case repo := <-reposChan:
-			httpFormattedRepos = append(httpFormattedRepos, repo...)
-		case err = <-errChan:
-			return nil, err
-		case <-doneChan:
-			close(errChan)
-			close(doneChan)
-			return httpFormattedRepos, nil
-		}
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for _, productChunk := range productsChunks {
+		go func(product, maint string) {
+			defer wg.Done()
+			repo, err := ProcWebChunk(client, product, maint)
+			if err != nil {
+				errChan <- err
+				return
+			}
+			reposChan <- repo
+		}(productChunk, mu)
 	}
+	wg.Wait()
+	close(reposChan)
+	close(errChan)
+
+	if err := <-errChan; err != nil {
+		return nil, err
+	}
+
+	var httpFormattedRepos []get.HTTPRepoConfig
+	for repo := range reposChan {
+		httpFormattedRepos = append(httpFormattedRepos, repo...)
+	}
+	return httpFormattedRepos, nil
 }
 
 // getProductsForMU parses a MU webpage attempting to retrieve a slice of available SUSE products

--- a/get/filestorage.go
+++ b/get/filestorage.go
@@ -3,7 +3,6 @@ package get
 import (
 	"crypto"
 	"io"
-	"log"
 	"os"
 	"path"
 	"path/filepath"
@@ -39,7 +38,7 @@ func (s *FileStorage) NewReader(filename string, location Location) (reader io.R
 
 	f, err := os.Open(fullPath)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 
 	return f, err

--- a/get/httpclient_test.go
+++ b/get/httpclient_test.go
@@ -2,7 +2,7 @@ package get
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 )
@@ -19,7 +19,7 @@ func TestReadURL(t *testing.T) {
 		t.Error(err)
 	}
 
-	result, err := ioutil.ReadAll(reader)
+	result, err := io.ReadAll(reader)
 	if err != nil {
 		t.Error(err)
 	}

--- a/get/s3storage.go
+++ b/get/s3storage.go
@@ -67,12 +67,10 @@ func configureBucket(region string, bucket string, client *s3.Client) error {
 	}
 	_, err := client.CreateBucket(context.Background(), input)
 	if err != nil {
-		var bucketExists *types.BucketAlreadyExists
-		var bucketOwnedByYou *types.BucketAlreadyOwnedByYou
-		if errors.As(err, &bucketExists) {
+		if _, ok := errors.AsType[*types.BucketAlreadyExists](err); ok {
 			return errors.New("Bucket name already taken by another AWS user, please use a different name")
 		}
-		if errors.As(err, &bucketOwnedByYou) {
+		if _, ok := errors.AsType[*types.BucketAlreadyOwnedByYou](err); ok {
 			return nil
 		}
 		return err
@@ -86,8 +84,7 @@ func getCurrentPrefix(bucket string, client *s3.Client) (result string, err erro
 		Bucket: aws.String(bucket),
 	})
 	if err != nil {
-		var apiErr smithy.APIError
-		if errors.As(err, &apiErr) && apiErr.ErrorCode() == "NoSuchWebsiteConfiguration" {
+		if apiErr, ok := errors.AsType[smithy.APIError](err); ok && apiErr.ErrorCode() == "NoSuchWebsiteConfiguration" {
 			return "", nil
 		}
 		return
@@ -157,8 +154,7 @@ func (s *S3Storage) NewReader(filename string, location Location) (reader io.Rea
 
 	info, err := s.client.GetObject(context.Background(), input)
 	if err != nil {
-		var apiErr smithy.APIError
-		if errors.As(err, &apiErr) && apiErr.ErrorCode() == "NoSuchKey" {
+		if apiErr, ok := errors.AsType[smithy.APIError](err); ok && apiErr.ErrorCode() == "NoSuchKey" {
 			err = ErrFileNotFound
 		}
 		return

--- a/get/syncer.go
+++ b/get/syncer.go
@@ -67,17 +67,17 @@ var hashMap = map[string]crypto.Hash{
 	"sha512": crypto.SHA512,
 }
 
-const repomdPath = "repodata/repomd.xml"
-const releasePath = "Release"
-
 type RepoType struct {
-	MetadataPath              string
-	PackagesType              string
-	DecodeMetadata            func(io.Reader) (XMLRepomd, error)
-	DecodePackages            func(io.Reader, string) (XMLMetaData, error)
-	MetadataSignatureExt      string
-	Noarch                    string
-	AdditionalMetadataPaths   []string
+	Name                   string
+	MetadataPath           string
+	PackagesType           string
+	DecodeMetadata         func(io.Reader, []string) (XMLRepomd, error)
+	DecodePackages         func(io.Reader, string) (XMLMetaData, error)
+	MetadataSignatureExt   string
+	Noarch                 string
+	RequiredKeys           []string
+	MandatoryMetadataPaths []string
+	OptionalMetadataPaths  []string
 }
 
 var (
@@ -86,11 +86,12 @@ var (
 		".deb":  {},
 		".udeb": {},
 	}
-	repoTypes = map[string]RepoType{
-		"rpm": {
+	repoTypes = []RepoType{
+		{
+			Name:         "rpm",
 			MetadataPath: "repodata/repomd.xml",
 			PackagesType: "primary",
-			DecodeMetadata: func(reader io.Reader) (repomd XMLRepomd, err error) {
+			DecodeMetadata: func(reader io.Reader, _ []string) (repomd XMLRepomd, err error) {
 				decoder := xml.NewDecoder(reader)
 				err = decoder.Decode(&repomd)
 				return
@@ -99,26 +100,28 @@ var (
 			MetadataSignatureExt: ".asc",
 			Noarch:               "noarch",
 		},
-		"deb": {
-			MetadataPath:            "Release",
-			PackagesType:            "Packages",
-			DecodeMetadata:          decodeRelease,
-			DecodePackages:          decodePackages,
-			MetadataSignatureExt:    ".gpg",
-			Noarch:                  "all",
-			AdditionalMetadataPaths: []string{"InRelease", "Release.gpg", "Release.key"},
+		{
+			Name:                  "deb",
+			MetadataPath:          "Release",
+			PackagesType:          "Packages",
+			DecodeMetadata:        decodeRelease,
+			DecodePackages:        decodePackages,
+			MetadataSignatureExt:  ".gpg",
+			Noarch:                "all",
+			RequiredKeys:          []string{"SHA256"},
+			OptionalMetadataPaths: []string{"InRelease"},
 		},
 	}
-	SkipLegacy bool
 )
 
 // Syncer syncs repos from an HTTP source to a Storage
 type Syncer struct {
 	// URL of the repo this syncer syncs
-	URL     url.URL
-	archs   map[string]bool
-	storage Storage
-	quiet   bool
+	URL         url.URL
+	archs       map[string]bool
+	storage     Storage
+	quiet       bool
+	skipLegacy  bool
 }
 
 // Decision encodes what to do with a file
@@ -134,14 +137,14 @@ const (
 )
 
 // NewSyncer creates a new Syncer
-func NewSyncer(url url.URL, archs map[string]bool, storage Storage, quiet bool) *Syncer {
-	return &Syncer{url, archs, storage, quiet}
+func NewSyncer(url url.URL, archs map[string]bool, storage Storage, quiet bool, skipLegacy bool) *Syncer {
+	return &Syncer{url, archs, storage, quiet, skipLegacy}
 }
 
 // StoreRepo stores an HTTP repo in a Storage, automatically retrying in case of recoverable errors
 func (r *Syncer) StoreRepo() (err error) {
 	checksumMap := r.readChecksumMap()
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		err = r.storeRepo(checksumMap)
 		if err == nil {
 			return
@@ -253,7 +256,7 @@ func (r *Syncer) processMetadata(checksumMap map[string]XMLChecksum) (packagesTo
 			return
 		}
 
-		repomd, err := repoType.DecodeMetadata(bytes.NewReader(b))
+		repomd, err := repoType.DecodeMetadata(bytes.NewReader(b), repoType.RequiredKeys)
 		if err != nil {
 			return
 		}
@@ -293,61 +296,35 @@ func (r *Syncer) processMetadata(checksumMap map[string]XMLChecksum) (packagesTo
 		return
 	}
 
-	err = r.downloadStoreApply(repomdPath, "", path.Base(repomdPath), 0, func(reader io.ReadCloser) (err error) {
-		err = doProcessMetadata(reader, repoTypes["rpm"])
-		return
-	})
-	if err != nil {
-		log.Println(err.Error())
-		log.Println("Fallback to next repo type")
-		// attempt to download Debian's Release file
-		err = r.downloadStoreApply(releasePath, "", path.Base(releasePath), 0, func(reader io.ReadCloser) (err error) {
-			err = doProcessMetadata(reader, repoTypes["deb"])
-			return
+	for _, repoType := range repoTypes {
+		log.Printf("Trying repo type: %s\n", repoType.Name)
+		err = r.downloadStoreApply(repoType.MetadataPath, "", path.Base(repoType.MetadataPath), 0, func(reader io.ReadCloser) error {
+			return doProcessMetadata(reader, repoType)
 		})
 		if err != nil {
-			return
+			log.Printf("Repo type %s failed: %v\n", repoType.Name, err)
+			log.Println("Fallback to next repo type")
+			continue
 		}
 
-		// DEB succeeded - download additional metadata files
-		// Note: Release.gpg and Release.key may have been downloaded by checkRepomdSignature()
-		// for verification. Check if they already exist before re-downloading.
-		isManagerTools := strings.Contains(r.URL.String(), "MultiLinuxManagerTools")
-		for _, file := range repoTypes["deb"].AdditionalMetadataPaths {
-			// Avoid re-downloading signature/key if they were already fetched during signature verification.
-			if file == "Release.gpg" || file == "Release.key" {
-				if reader, rerr := r.storage.NewReader(file, Temporary); rerr == nil {
-					_ = reader.Close()
-					continue
-				} else if rerr != ErrFileNotFound {
-					err = rerr
-					return
-				}
-			}
-
-			extraErr := r.downloadStoreApply(file, "", file, 0, util.Nop)
-			if extraErr == nil {
-				continue
-			}
-
-			// Only strictly enforce Release.gpg for MultiLinuxManagerTools repositories.
-			if isManagerTools && file == "Release.gpg" {
-				// Don't ignore any errors for required file; propagate so StoreRepo can retry.
-				err = extraErr
+		for _, mandatoryPath := range repoType.MandatoryMetadataPaths {
+			err = r.downloadStoreApply(mandatoryPath, "", mandatoryPath, 0, util.Nop)
+			if err != nil {
+				log.Printf("Failed to download mandatory file %s, retrying sync: %v \n", mandatoryPath, err)
 				return
 			}
-
-			// For optional files, ignore 403/404 (file doesn't exist)
-			ignoredErr := ignoreStatusCode(extraErr, 403, 404)
-			if ignoredErr == nil {
-				continue
-			}
-
-			// Non-403/404 error on optional file: propagate so StoreRepo can retry instead of committing corrupt state
-			log.Printf("Failed to download optional file %s, retrying sync: %v\n", file, ignoredErr)
-			err = ignoredErr
-			return
 		}
+
+		for _, optionalPath := range repoType.OptionalMetadataPaths {
+			optErr := r.downloadStoreApply(optionalPath, "", path.Base(optionalPath), 0, util.Nop)
+			optErr = ignoreStatusCode(optErr, 403, 404)
+			if optErr != nil {
+				log.Printf("Failed to download optional file %s, retrying sync: %v\n", optionalPath, optErr)
+				err = optErr
+				return
+			}
+		}
+		break
 	}
 	return
 }
@@ -438,35 +415,38 @@ func readMetaData(reader io.Reader, compType string) (XMLMetaData, error) {
 func (r *Syncer) readChecksumMap() (checksumMap map[string]XMLChecksum) {
 	checksumMap = make(map[string]XMLChecksum)
 
-	repoType := repoTypes["rpm"]
-	repomdReader, err := r.storage.NewReader(repomdPath, Permanent)
-	if err != nil {
-		if err == ErrFileNotFound {
-			repomdReader, err = r.storage.NewReader(releasePath, Permanent)
-			if err != nil {
-				log.Println("First-time sync started")
-				return
-			}
-			repoType = repoTypes["deb"]
-		} else {
+	var repoType RepoType
+	var repomdReader io.ReadCloser
+	for _, rt := range repoTypes {
+		var err error
+		repomdReader, err = r.storage.NewReader(rt.MetadataPath, Permanent)
+		if err == nil {
+			repoType = rt
+			break
+		}
+		if err != ErrFileNotFound {
 			log.Println("Error while reading previously-downloaded metadata. Starting sync from scratch")
 			return
 		}
 	}
+	if repomdReader == nil {
+		log.Println("First-time sync started")
+		return
+	}
 	defer repomdReader.Close()
 
-	repomd, err := repoType.DecodeMetadata(repomdReader)
+	repomd, err := repoType.DecodeMetadata(repomdReader, repoType.RequiredKeys)
 	if err != nil {
 		log.Println("Error while parsing previously-downloaded metadata. Starting sync from scratch")
 		return
 	}
 
 	data := repomd.Data
-	for i := 0; i < len(data); i++ {
-		dataHref := data[i].Location.Href
-		dataChecksum := data[i].Checksum
+	for _, d := range data {
+		dataHref := d.Location.Href
+		dataChecksum := d.Checksum
 		checksumMap[dataHref] = dataChecksum
-		if data[i].Type == repoType.PackagesType {
+		if d.Type == repoType.PackagesType {
 			primaryReader, err := r.storage.NewReader(dataHref, Permanent)
 			if err != nil {
 				return
@@ -502,7 +482,7 @@ func (r *Syncer) processPrimary(path string, checksumMap map[string]XMLChecksum,
 	for _, pack := range primary.Packages {
 		legacyPackage := (pack.Arch == "i586" || pack.Arch == "i686")
 
-		if SkipLegacy && legacyPackage {
+		if r.skipLegacy && legacyPackage {
 			if !r.quiet {
 				fmt.Println("Skipping legacy package:", pack.Location.Href)
 			}
@@ -551,7 +531,7 @@ func (r *Syncer) decide(location string, checksum XMLChecksum, checksumMap map[s
 }
 
 // Functions to handle Debian formatted repositories
-func decodeRelease(reader io.Reader) (repomd XMLRepomd, err error) {
+func decodeRelease(reader io.Reader, requiredKeys []string) (repomd XMLRepomd, err error) {
 	entries, err := util.ProcessPropertiesFile(reader)
 	if err != nil {
 		return
@@ -560,11 +540,18 @@ func decodeRelease(reader io.Reader) (repomd XMLRepomd, err error) {
 		err = errors.New("no content in Release file")
 		return
 	}
-	if len(entries[0]["SHA256"]) == 0 {
-		err = errors.New("missing SHA256 entry in Release file")
+	var fileListKey string
+	for _, key := range requiredKeys {
+		if len(entries[0][key]) > 0 {
+			fileListKey = key
+			break
+		}
+	}
+	if fileListKey == "" {
+		err = fmt.Errorf("missing required key(s) %v in Release file", requiredKeys)
 		return
 	}
-	fileEntries := strings.Split(entries[0]["SHA256"], "\n")
+	fileEntries := strings.Split(entries[0][fileListKey], "\n")
 
 	data := make([]XMLData, 0)
 	for _, fileEntry := range fileEntries {

--- a/get/syncer_test.go
+++ b/get/syncer_test.go
@@ -26,7 +26,7 @@ func TestStoreRepo(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	syncer := NewSyncer(*url, archs, storage, false)
+	syncer := NewSyncer(*url, archs, storage, false, false)
 
 	// first sync
 	err = syncer.StoreRepo()
@@ -83,7 +83,7 @@ func TestStoreRepoZstd(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	syncer := NewSyncer(*url, archs, storage, false)
+	syncer := NewSyncer(*url, archs, storage, false, false)
 
 	// first sync
 	err = syncer.StoreRepo()
@@ -140,7 +140,7 @@ func TestStoreDebRepo(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	syncer := NewSyncer(*url, archs, storage, false)
+	syncer := NewSyncer(*url, archs, storage, false, false)
 
 	// first sync
 	err = syncer.StoreRepo()

--- a/updates/obs_data.go
+++ b/updates/obs_data.go
@@ -71,14 +71,14 @@ type State struct {
 	Comment string `xml:"comment"`
 }
 type Review struct {
-	State      string `xml:"state,attr"`
-	By_user    string `xml:"by_user,attr"`
-	By_group   string `xml:"by_group,attr"`
-	By_project string `xml:"by_project,attr"`
-	By_package string `xml:"by_package,attr"`
-	Who        string `xml:"who,attr"`
-	When       string `xml:"when,attr"`
-	Comment    string `xml:"comment"`
+	State     string `xml:"state,attr"`
+	ByUser    string `xml:"by_user,attr"`
+	ByGroup   string `xml:"by_group,attr"`
+	ByProject string `xml:"by_project,attr"`
+	ByPackage string `xml:"by_package,attr"`
+	Who       string `xml:"who,attr"`
+	When      string `xml:"when,attr"`
+	Comment   string `xml:"comment"`
 }
 type History struct {
 	Who         string `xml:"who,attr"`
@@ -96,7 +96,7 @@ type ReleaseRequest struct {
 	Reviews     []Review  `xml:"review"`       //zeroOrMore
 	Histories   []History `xml:"history"`      //zeroOrMore
 	Title       string    `xml:"title"`        //optional
-	Accept_at   string    `xml:"accept_at"`    //optional
+	AcceptAt    string    `xml:"accept_at"`    //optional
 }
 type Collection struct {
 	Matches         string           `xml:"matches,attr"`

--- a/util/io.go
+++ b/util/io.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"hash"
 	"io"
-	"io/ioutil"
 )
 
 // ReaderConsumer consumes bytes from a Reader
@@ -76,7 +75,7 @@ var discardBuffer = make([]byte, 4*1024*1024)
 // Close closes the internal reader and writer
 func (t *TeeReadCloser) Close() (err error) {
 	// read any remaining bytes from the teeReader (discarding them)
-	_, err = io.CopyBuffer(ioutil.Discard, t.teeReader, discardBuffer)
+	_, err = io.CopyBuffer(io.Discard, t.teeReader, discardBuffer)
 	if err != nil {
 		t.reader.Close()
 		t.writer.Close()

--- a/util/io_test.go
+++ b/util/io_test.go
@@ -3,14 +3,13 @@ package util
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"testing"
 )
 
 func TestCompose(t *testing.T) {
 	helloWorldReader := NewNopReadCloser(bytes.NewBufferString("Hello, World"))
 	bangMapper := func(r io.ReadCloser) (result io.ReadCloser, err error) {
-		raw, err := ioutil.ReadAll(r)
+		raw, err := io.ReadAll(r)
 		if err != nil {
 			t.Error(err)
 		}
@@ -19,7 +18,7 @@ func TestCompose(t *testing.T) {
 	}
 
 	composedReaderFunction := Compose(bangMapper, func(reader io.ReadCloser) (err error) {
-		result, err := ioutil.ReadAll(reader)
+		result, err := io.ReadAll(reader)
 		if err != nil {
 			t.Error(err)
 		}


### PR DESCRIPTION
Various refactor and fixes, with the help of Claude.

---
  Code quality improvements and refactoring
     
  Bug fixes

  - Goroutine leak in GetRepo (cmd/updates.go): worker goroutines blocked forever on
  unbuffered channels when an error caused early return. Fix: buffer channels with n
  capacity, move wg.Wait() to the main goroutine, eliminate coordinator goroutine and
  doneChan. Workers also no longer send to reposChan after sending an error.
  - log.Fatal in library code (get/filestorage.go): NewReader called log.Fatal on os.Open
  failure, making the error unhandlable by callers. Replaced with return nil, err.

  Architecture

  - SkipLegacy global removed (get/syncer.go, cmd/sync.go): package-level mutable bool
  crossing package boundary replaced by a skipLegacy bool field on Syncer, passed through
  NewSyncer. Eliminates a potential data race if syncers are ever run concurrently.
  - repoTypes/repoTypesConfigs unified (get/syncer.go): parallel []string +
  map[string]RepoType structures replaced by a single ordered []RepoType slice. Order is
  now explicit in the data; map key lookups eliminated. A Name field added to RepoType for
  logging which format is being tried and which failed.
  - DecodeMetadata signature generalized: accepts requiredKeys []string instead of
  hardcoding the SHA256 check inside decodeRelease, making the DEB metadata key
  requirement declarative and consistent with the RepoType config.

  Cleanup

  - ioutil.Discard → io.Discard (util/io.go): ioutil deprecated since Go 1.16; module
  targets Go 1.24.
  - CamelCase field names in updates/obs_data.go: By_user, By_group, By_project,
  By_package, Accept_at renamed to ByUser, ByGroup, ByProject, ByPackage, AcceptAt. XML
  struct tags unchanged.
  - Loop modernizations in get/syncer.go: for i := 0; i < 20; i++ → for range 20;
  index-based slice loop → for _, d := range data.